### PR TITLE
Broker naming refactor

### DIFF
--- a/dispatcher/src/cli.rs
+++ b/dispatcher/src/cli.rs
@@ -11,7 +11,7 @@ use std::{
 
 use anyhow::Result;
 use bitvmx_broker::{
-    channel::channel::DualChannel,
+    RemoteChannel,
     identification::allow_list::AllowList,
     rpc::{tls_helper::Cert, BrokerConfig},
 };
@@ -76,7 +76,7 @@ fn init_trace() -> Result<(), DispatcherError> {
 
 pub fn init() -> Result<
     (
-        DualChannel,
+        RemoteChannel,
         Duration,
         Arc<AtomicBool>,
         Rc<Storage>,
@@ -110,7 +110,7 @@ pub fn init() -> Result<
         args.broker_pubk_hash,
         None, // Default config
     );
-    let channel = DualChannel::new(&config, cert, Some(my_id), allow_list)?;
+    let channel = RemoteChannel::new(&config, cert, Some(my_id), allow_list)?;
     let check_interval = std::time::Duration::from_secs(1);
 
     let running = Arc::new(AtomicBool::new(true));

--- a/dispatcher/src/lib.rs
+++ b/dispatcher/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
     time::Duration,
 };
 
-use bitvmx_broker::{channel::channel::DualChannel, identification::identifier::Identifier};
+use bitvmx_broker::{RemoteChannel, identification::identifier::Identifier};
 
 use bitvmx_dispatcher_utils::{Msg, PingMessage};
 use dispatcher_job::ResultMessage;
@@ -49,7 +49,7 @@ impl JobContext {
     }
 }
 pub struct DispatcherHandler<T: DispatcherMessage + DeserializeOwned> {
-    channel: DualChannel,
+    channel: RemoteChannel,
     workers: Vec<(Child, Identifier, JobContext)>,
     storage: Rc<DispatcherStorage>,
     _phantom_data: std::marker::PhantomData<T>,
@@ -63,7 +63,7 @@ where
     T: DispatcherMessage + DeserializeOwned,
 {
     pub fn new(
-        channel: DualChannel,
+        channel: RemoteChannel,
         storage: Rc<Storage>,
         config: Option<String>,
         #[cfg(feature = "aws")] local_mode: bool,
@@ -108,7 +108,7 @@ where
     }
 
     pub fn new_with_path(
-        channel: DualChannel,
+        channel: RemoteChannel,
         storage_path: &str,
         config: Option<String>,
         local_mode: bool,
@@ -318,7 +318,7 @@ where
 }
 
 pub fn dispatcher_loop<T: DispatcherMessage + DeserializeOwned + std::fmt::Debug>(
-    channel: DualChannel,
+    channel: RemoteChannel,
     check_interval: Duration,
     running: Arc<AtomicBool>,
     storage: Rc<Storage>,

--- a/emulator-dispatcher/examples/challenge.rs
+++ b/emulator-dispatcher/examples/challenge.rs
@@ -11,7 +11,7 @@ use tracing::error;
 //      cargo run --release --example challenge
 pub mod emulator {
 
-    use bitvmx_broker::channel::channel::DualChannel;
+    use bitvmx_broker::RemoteChannel;
     use bitvmx_cpu_definitions::challenge::{EmulatorResultType, ProverFinalTraceType};
     use bitvmx_job_dispatcher::dispatcher_job::{DispatcherJob, ResultMessage};
     use bitvmx_job_dispatcher_types::emulator_messages::EmulatorJobType;
@@ -187,7 +187,7 @@ pub mod emulator {
     }
 
     fn wait_for_typed_result(
-        channel: &DualChannel,
+        channel: &RemoteChannel,
         expected_type: &str,
         max_attempts: usize,
         delay_secs: u64,

--- a/emulator-dispatcher/examples/ping.rs
+++ b/emulator-dispatcher/examples/ping.rs
@@ -13,7 +13,7 @@ mod challenge;
 //      cargo run --release --example challenge --features "emulator"
 
 pub mod emulator {
-    use bitvmx_broker::channel::channel::DualChannel;
+    use bitvmx_broker::RemoteChannel;
     use bitvmx_dispatcher_utils::PingMessage;
     use test_helper::test_helper::{configure_example_broker, wait_for_result, Paths};
     use tracing::info;
@@ -40,7 +40,7 @@ pub mod emulator {
     }
 
     fn wait_for_ping(
-        channel: &DualChannel,
+        channel: &RemoteChannel,
         max_attempts: usize,
         delay_secs: u64,
     ) -> Result<PingMessage, anyhow::Error> {

--- a/garbled-dispatcher/examples/garbled_client.rs
+++ b/garbled-dispatcher/examples/garbled_client.rs
@@ -1,7 +1,7 @@
 use std::{fs, thread::sleep, time::Duration};
 
 use anyhow::Result;
-use bitvmx_broker::channel::channel::DualChannel;
+use bitvmx_broker::RemoteChannel;
 use bitvmx_job_dispatcher::dispatcher_job::{DispatcherJob, ResultMessage};
 use bitvmx_job_dispatcher_types::garbled_messages::{GCJobProveResult, GarbledJobType, ProofBlob};
 use test_helper::test_helper::{configure_example_broker, init_trace, Paths};
@@ -124,7 +124,7 @@ fn run_garbled_job(port: u16) -> Result<()> {
 }
 
 fn wait_for_result(
-    channel: &DualChannel,
+    channel: &RemoteChannel,
     expected_type: &str,
     max_attempts: usize,
     delay_secs: u64,

--- a/test-helper/src/test_helper.rs
+++ b/test-helper/src/test_helper.rs
@@ -8,9 +8,9 @@ use std::{
 };
 
 use bitvmx_broker::{
-    channel::channel::DualChannel,
+    RemoteChannel,
     identification::{allow_list::AllowList, identifier::Identifier, routing::RoutingTable},
-    rpc::{BrokerConfig, sync_server::BrokerSync, tls_helper::Cert},
+    rpc::{BrokerConfig, tls_helper::Cert}, BrokerServer,
 };
 use bitvmx_job_dispatcher::{get_storage_with_path, helper::remove_storage_path};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -51,7 +51,7 @@ fn config_trace_aux() {
 // Broker / Server Setup
 // ======================================================
 
-pub fn init_server(port: u16) -> Result<BrokerSync, anyhow::Error> {
+pub fn init_server(port: u16) -> Result<BrokerServer, anyhow::Error> {
     let privk = fs::read_to_string("test-helper/cert/services.key").unwrap();
     let cert = Cert::new_with_privk(&privk).unwrap();
     let allow_list = AllowList::new();
@@ -62,12 +62,10 @@ pub fn init_server(port: u16) -> Result<BrokerSync, anyhow::Error> {
 
     let config = BrokerConfig::new(port, None, cert.get_pubk_hash().unwrap(), None);
 
-    let storage = Arc::new(Mutex::new(
-        bitvmx_broker::broker_memstorage::MemStorage::new(),
-    ));
+    let storage = Arc::new(Mutex::new(bitvmx_broker::storage::memory::MemStorage::new()));
 
     let server =
-        BrokerSync::new(&config, storage.clone(), cert, allow_list.clone(), routing).unwrap();
+        BrokerServer::new(&config, storage.clone(), cert, allow_list.clone(), routing).unwrap();
 
     Ok(server)
 }
@@ -76,7 +74,7 @@ pub fn config_broker(
     rt: Option<Arc<Mutex<Runtime>>>,
     storage_path: &str,
     paths: &Paths,
-) -> (DualChannel, Duration, Rc<Storage>) {
+) -> (RemoteChannel, Duration, Rc<Storage>) {
     let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let my_id = 1;
 
@@ -95,9 +93,9 @@ pub fn config_broker(
 
     let channel = match rt {
         Some(rt) => {
-            DualChannel::new_with_runtime(&config, cert, Some(my_id), allow_list, rt).unwrap()
+            RemoteChannel::new_with_runtime(&config, cert, Some(my_id), allow_list, rt).unwrap()
         }
-        None => DualChannel::new(&config, cert, Some(my_id), allow_list).unwrap(),
+        None => RemoteChannel::new(&config, cert, Some(my_id), allow_list).unwrap(),
     };
 
     let check_interval = Duration::from_secs(1);
@@ -155,7 +153,7 @@ impl Paths {
 pub fn configure_example_broker(
     paths: &Paths,
     port: u16,
-) -> Result<(DualChannel, Identifier), anyhow::Error> {
+) -> Result<(RemoteChannel, Identifier), anyhow::Error> {
     let privk = fs::read_to_string(paths.privk.clone())?;
 
     let my_id = 2;
@@ -166,7 +164,7 @@ pub fn configure_example_broker(
     let allow_list = AllowList::new();
     allow_list.lock().unwrap().allow_all();
 
-    let channel = DualChannel::new(
+    let channel = RemoteChannel::new(
         &BrokerConfig::new(
             port,
             Some(IpAddr::from([127, 0, 0, 1])),
@@ -189,7 +187,7 @@ pub fn configure_example_broker(
 }
 
 pub fn wait_for_result<T, F>(
-    channel: &DualChannel,
+    channel: &RemoteChannel,
     max_attempts: usize,
     delay_secs: u64,
     mut parser: F,


### PR DESCRIPTION
Adapt to broker naming refactor.

override: rust-bitvmx-broker: naming-refactor