### PR TITLE
Acknowledge messages only once the work they caused is stored

### DIFF
--- a/dispatcher/src/cli.rs
+++ b/dispatcher/src/cli.rs
@@ -11,9 +11,9 @@ use std::{
 
 use anyhow::Result;
 use bitvmx_broker::{
-    RemoteChannel,
     identification::allow_list::AllowList,
     rpc::{tls_helper::Cert, BrokerConfig},
+    RemoteChannel,
 };
 
 use clap::Parser;

--- a/dispatcher/src/dispatcher_storage.rs
+++ b/dispatcher/src/dispatcher_storage.rs
@@ -28,10 +28,17 @@ impl DispatcherStorage {
         Ok(self.storage.has_key(&key, None)?)
     }
 
+    /// Persists a job to the storage backend. Uses a transaction to ensure that the job is fully persisted.
     pub fn persist_job(&self, job_id: &str, raw_msg: &str) -> Result<(), DispatcherError> {
         let key = job_key(job_id);
-        self.storage.set(&key, raw_msg.to_string(), None)?;
-        Ok(())
+        let tx = self.storage.begin_transaction();
+        match self.storage.set(&key, raw_msg.to_string(), Some(tx)) {
+            Ok(()) => Ok(self.storage.commit_transaction(tx)?),
+            Err(e) => {
+                let _ = self.storage.rollback_transaction(tx);
+                Err(e.into())
+            }
+        }
     }
 
     pub fn get_job(&self, job_id: &str) -> Result<Option<String>, DispatcherError> {
@@ -68,11 +75,19 @@ impl DispatcherStorage {
         result: (String, Identifier),
     ) -> Result<(), DispatcherError> {
         let key = result_key(job_id);
-        let tx = Some(self.storage.begin_transaction());
-        self.storage.set(&key, result, tx)?;
-        self.storage.remove(&job_key(job_id), tx)?;
-        self.storage.commit_transaction(tx.unwrap())?;
-        Ok(())
+        let tx = self.storage.begin_transaction();
+        let written = self
+            .storage
+            .set(&key, result, Some(tx))
+            .and_then(|_| self.storage.remove(&job_key(job_id), Some(tx)));
+
+        match written {
+            Ok(()) => Ok(self.storage.commit_transaction(tx)?),
+            Err(e) => {
+                let _ = self.storage.rollback_transaction(tx);
+                Err(e.into())
+            }
+        }
     }
 
     pub fn get_results(&self) -> Result<Vec<(String, (String, Identifier))>, DispatcherError> {

--- a/dispatcher/src/lib.rs
+++ b/dispatcher/src/lib.rs
@@ -169,7 +169,7 @@ where
                     Err(e) => {
                         // Retrying can never make this parse, and leaving it in place would block
                         // every message behind it, so it is dropped.
-                        warn!("Discarding undecodable message from {}: {:?}", msg.id, e);
+                        error!("Discarding undecodable message from {}: {:?}", msg.id, e);
                         self.channel.ack(uid)?;
                         return Ok(());
                     }

--- a/dispatcher/src/lib.rs
+++ b/dispatcher/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
     time::Duration,
 };
 
-use bitvmx_broker::{RemoteChannel, identification::identifier::Identifier};
+use bitvmx_broker::{identification::identifier::Identifier, RemoteChannel};
 
 use bitvmx_dispatcher_utils::{Msg, PingMessage};
 use dispatcher_job::ResultMessage;
@@ -136,21 +136,25 @@ where
         Ok(())
     }
 
+    // Takes one message and acknowledges it only once whatever it caused is safely stored.
     fn create_new_jobs(&mut self) -> Result<(), DispatcherError> {
-        let msg = self.channel.recv();
+        let msg = self.channel.get();
         if msg.is_err() {
             warn!("Failed to receive message from channel: {:?}", msg.err());
             return Ok(());
         }
-        let msg = msg.unwrap();
 
-        if let Some(msg) = msg {
-            let msg = Msg::from_msg(msg.clone());
+        if let Some(msg) = msg.unwrap() {
+            let uid = msg.uid;
+            let msg = Msg::from_msg((msg.msg, msg.from));
+
             if let Some(message) = serde_json::from_str::<PingMessage>(&msg.raw).ok() {
                 match message {
                     PingMessage::Ping => debug!("Received Ping"),
                     PingMessage::Pong => {
                         warn!("Job Dispatcher should not receive Pong");
+                        // Consumed even though it is ignored, otherwise it stays at the head of the queue for ever.
+                        self.channel.ack(uid)?;
                         return Ok(());
                     }
                 }
@@ -158,8 +162,19 @@ where
                 let pong = serde_json::to_string(&PingMessage::Pong)?;
 
                 self.channel.send(&msg.id, pong)?;
+                self.channel.ack(uid)?;
             } else {
-                let job: DispatcherJob<T> = decode_msg(&msg.raw)?;
+                let job: DispatcherJob<T> = match decode_msg(&msg.raw) {
+                    Ok(job) => job,
+                    Err(e) => {
+                        // Retrying can never make this parse, and leaving it in place would block
+                        // every message behind it, so it is dropped.
+                        warn!("Discarding undecodable message from {}: {:?}", msg.id, e);
+                        self.channel.ack(uid)?;
+                        return Ok(());
+                    }
+                };
+
                 if self.storage.contains_job(&job.job_id())? {
                     warn!("Job with id {} already exists, skipping", job.job_id());
                 } else {
@@ -169,6 +184,7 @@ where
                         self.workers.push((child, msg.id.clone(), context));
                     }
                 }
+                self.channel.ack(uid)?;
             }
         }
         Ok(())
@@ -232,7 +248,9 @@ where
                                             "Successfully extracted structured JSON for job {}: {}",
                                             context.job_id, res
                                         );
-                                        job.job_type().commit_checkpoint(context.temp_checkpoint_output_path.clone())?;
+                                        job.job_type().commit_checkpoint(
+                                            context.temp_checkpoint_output_path.clone(),
+                                        )?;
                                         (res, false)
                                     }
                                     Err(e) => {
@@ -361,7 +379,11 @@ where
     info!("Command: {:?}", cmd);
     info!("Args: {:?}", args);
 
-    let job_context = JobContext::new(msg.job_id.clone(), command_file.clone(), temp_checkpoint_output_path);
+    let job_context = JobContext::new(
+        msg.job_id.clone(),
+        command_file.clone(),
+        temp_checkpoint_output_path,
+    );
     let child = Command::new(cmd).args(args).spawn()?;
 
     Ok((child, job_context))

--- a/garbled-dispatcher/examples/garbled_client.rs
+++ b/garbled-dispatcher/examples/garbled_client.rs
@@ -42,10 +42,7 @@ fn run_garbled_job(port: u16) -> Result<()> {
     // Simple circuit: y = (a & b) ^ d
     let prove_job = DispatcherJob {
         job_id: "prove_simple_001".to_string(),
-        job_type: GarbledJobType::Prove(
-            circuit_path.to_string(),
-            format!("{}/prove", output_dir),
-        ),
+        job_type: GarbledJobType::Prove(circuit_path.to_string(), format!("{}/prove", output_dir)),
     };
 
     let msg = serde_json::to_string(&prove_job)?;

--- a/jobtypes/src/emulator_messages.rs
+++ b/jobtypes/src/emulator_messages.rs
@@ -1,6 +1,4 @@
-use std::{
-    fs, path::PathBuf
-};
+use std::{fs, path::PathBuf};
 
 use bitvmx_cpu_definitions::{
     //challenge::{ChallengeType, EmulatorResultType},
@@ -41,7 +39,12 @@ impl DispatcherMessage for EmulatorJobType {
                     "--command-file".to_string(),
                     command_file.clone(),
                 ];
-                Ok((EMULATOR_PATH.to_string(), args, command_file.to_string(), "".to_string()))
+                Ok((
+                    EMULATOR_PATH.to_string(),
+                    args,
+                    command_file.to_string(),
+                    "".to_string(),
+                ))
             }
             EmulatorJobType::ProverExecute(yaml, input, _, command_file, fail_config_prover) => {
                 let hex_input = hex::encode(input);
@@ -65,7 +68,12 @@ impl DispatcherMessage for EmulatorJobType {
                     args.push(fcp.to_string());
                 }
 
-                Ok((EMULATOR_PATH.to_string(), args, command_file.to_string(), output_path))
+                Ok((
+                    EMULATOR_PATH.to_string(),
+                    args,
+                    command_file.to_string(),
+                    output_path,
+                ))
             }
             EmulatorJobType::VerifierCheckExecution(
                 yaml,
@@ -104,7 +112,12 @@ impl DispatcherMessage for EmulatorJobType {
                 args.push("--force".to_string());
                 args.push(force.to_string());
 
-                Ok((EMULATOR_PATH.to_string(), args, command_file.to_string(), output_path))
+                Ok((
+                    EMULATOR_PATH.to_string(),
+                    args,
+                    command_file.to_string(),
+                    output_path,
+                ))
             }
             EmulatorJobType::ProverGetHashesForRound(
                 pdf,
@@ -138,7 +151,12 @@ impl DispatcherMessage for EmulatorJobType {
                     args.push(fcp.to_string());
                 }
 
-                Ok((EMULATOR_PATH.to_string(), args, command_file.to_string(), output_path))
+                Ok((
+                    EMULATOR_PATH.to_string(),
+                    args,
+                    command_file.to_string(),
+                    output_path,
+                ))
             }
             EmulatorJobType::VerifierChooseSegment(
                 pdf,
@@ -176,7 +194,12 @@ impl DispatcherMessage for EmulatorJobType {
                     args.push(i.to_string());
                 }
 
-                Ok((EMULATOR_PATH.to_string(), args, command_file.to_string(), output_path))
+                Ok((
+                    EMULATOR_PATH.to_string(),
+                    args,
+                    command_file.to_string(),
+                    output_path,
+                ))
             }
             EmulatorJobType::ProverFinalTrace(
                 pdf,
@@ -204,7 +227,12 @@ impl DispatcherMessage for EmulatorJobType {
                     args.push(fcp.to_string());
                 }
 
-                Ok((EMULATOR_PATH.to_string(), args, command_file.to_string(), output_path))
+                Ok((
+                    EMULATOR_PATH.to_string(),
+                    args,
+                    command_file.to_string(),
+                    output_path,
+                ))
             }
             EmulatorJobType::VerifierChooseChallenge(
                 pdf,
@@ -241,7 +269,12 @@ impl DispatcherMessage for EmulatorJobType {
                     args.push(fcv.to_string());
                 }
 
-                Ok((EMULATOR_PATH.to_string(), args, command_file.to_string(), output_path))
+                Ok((
+                    EMULATOR_PATH.to_string(),
+                    args,
+                    command_file.to_string(),
+                    output_path,
+                ))
             }
             EmulatorJobType::VerifierChooseChallengeForReadChallenge(
                 pdf,
@@ -275,7 +308,12 @@ impl DispatcherMessage for EmulatorJobType {
                     args.push(fcv.to_string());
                 }
 
-                Ok((EMULATOR_PATH.to_string(), args, command_file.to_string(), output_path))
+                Ok((
+                    EMULATOR_PATH.to_string(),
+                    args,
+                    command_file.to_string(),
+                    output_path,
+                ))
             }
             EmulatorJobType::ProverGetHashesAndStep(
                 pdf,
@@ -301,7 +339,12 @@ impl DispatcherMessage for EmulatorJobType {
                     args.push(fcp.to_string());
                 }
 
-                Ok((EMULATOR_PATH.to_string(), args, command_file.to_string(), output_path))
+                Ok((
+                    EMULATOR_PATH.to_string(),
+                    args,
+                    command_file.to_string(),
+                    output_path,
+                ))
             }
         }
     }
@@ -412,11 +455,19 @@ impl EmulatorJobType {
     pub fn checkpoint_input(&self) -> Result<Option<String>, DispatcherError> {
         match self {
             EmulatorJobType::ProverExecute(_, _, base, _, _) => Ok(Some(base.clone())),
-            EmulatorJobType::VerifierCheckExecution(_, _, base, _, _, _, _, _) => Ok(Some(base.clone())),
-            EmulatorJobType::ProverGetHashesForRound(_, base, _, _, _, _, _) => Ok(Some(base.clone())),
-            EmulatorJobType::VerifierChooseSegment(_, base, _, _, _, _, _) => Ok(Some(base.clone())),
+            EmulatorJobType::VerifierCheckExecution(_, _, base, _, _, _, _, _) => {
+                Ok(Some(base.clone()))
+            }
+            EmulatorJobType::ProverGetHashesForRound(_, base, _, _, _, _, _) => {
+                Ok(Some(base.clone()))
+            }
+            EmulatorJobType::VerifierChooseSegment(_, base, _, _, _, _, _) => {
+                Ok(Some(base.clone()))
+            }
             EmulatorJobType::ProverFinalTrace(_, base, _, _, _) => Ok(Some(base.clone())),
-            EmulatorJobType::VerifierChooseChallenge(_, base, _, _, _, _, _, _) => Ok(Some(base.clone())),
+            EmulatorJobType::VerifierChooseChallenge(_, base, _, _, _, _, _, _) => {
+                Ok(Some(base.clone()))
+            }
             EmulatorJobType::VerifierChooseChallengeForReadChallenge(_, base, _, _, _, _, _) => {
                 Ok(Some(base.clone()))
             }
@@ -439,7 +490,7 @@ impl EmulatorJobType {
             }
             fs::remove_dir_all(temp_checkpoint_path)?;
         }
-        
+
         Ok(())
     }
 }

--- a/test-helper/src/test_helper.rs
+++ b/test-helper/src/test_helper.rs
@@ -8,9 +8,9 @@ use std::{
 };
 
 use bitvmx_broker::{
-    RemoteChannel,
+    BrokerServer, RemoteChannel,
     identification::{allow_list::AllowList, identifier::Identifier, routing::RoutingTable},
-    rpc::{BrokerConfig, tls_helper::Cert}, BrokerServer,
+    rpc::{BrokerConfig, tls_helper::Cert},
 };
 use bitvmx_job_dispatcher::{get_storage_with_path, helper::remove_storage_path};
 use std::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
## Changes
The dispatcher stops using `recv()`, which acknowledges a message before the caller has seen it. It now takes the message with `get()` and acknowledges once whatever the message caused is safely on disk.

### Ack ordering
* `create_new_jobs` holds the uid from `get()` and calls `ack(uid)` after the durable step: ping after `send(pong)`, job after `persist_job`.
* Storage errors still propagate without acking, so they retry once storage recovers.
* Two paths that previously relied on `recv` consuming the message now acknowledge explicitly: an undecodable message, and a stray `Pong`.

### Storage durability
* `persist_job` and `complete_job` write inside their own `begin_transaction` / `commit_transaction` with rollback on error.

## Bugs fixed
* **Jobs were lost on any failure after receipt.** `recv()` dropped the broker's copy while the only remaining one was in memory, so a parse error, storage error, panic or kill before `persist_job` lost the job entirely. 
* **Two paths would have blocked the queue permanently.** The broker returns the oldest unacknowledged message on every `get`, so anything never acknowledged stops everything behind it, across restarts. An undecodable message previously killed the process through `decode_msg(...)?`, survivable only because `recv` had already consumed it; it is now logged and acked, since retrying cannot make it parse. A stray `Pong` returned early relying on the same thing, and would otherwise be re-read and warned about on every tick.

override: rust-bitvmx-broker: broker-peers-services-split